### PR TITLE
allow ask = FALSE in plots

### DIFF
--- a/R/plot.gpcm.R
+++ b/R/plot.gpcm.R
@@ -1,10 +1,11 @@
 plot.gpcm <-
-function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NULL, 
-                      zrange = c(-3.8, 3.8), z = seq(zrange[1], zrange[2], length = 100), annot, 
-                      labels = NULL, legend = FALSE, 
-                      cx = "top", cy = NULL, ncol = 1, bty = "n", col = palette(), lty = 1, pch, 
-                      xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"), 
-                      cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"), 
+function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NULL,
+                      zrange = c(-3.8, 3.8), z = seq(zrange[1], zrange[2], length = 100), annot,
+                      labels = NULL, legend = FALSE,
+                      cx = "top", cy = NULL, ncol = 1, bty = "n", col = palette(), lty = 1, pch,
+                      xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"),
+                      cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"),
+                      ask = TRUE,
                       plot = TRUE, ...) {
     if (!inherits(x, "gpcm"))
         stop("Use only with 'gpcm' objects.\n")
@@ -29,7 +30,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             stop(paste("'category' must be a number between 1 and ", max(ncatg), ".\n", sep = ""))
         if (any(ind <- category > ncatg)){
             if (sum(ind) > 1)
-                warning("Items ", paste(items[ind], collapse = ", "), " are excluded since they have only ", 
+                warning("Items ", paste(items[ind], collapse = ", "), " are excluded since they have only ",
                             paste(ncatg[ind], collapse = ", "), " categories, respectively.\n")
             else
                 warning("Item ", items[ind], " is excluded since they have only ", ncatg[ind], " categories.\n")
@@ -40,7 +41,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
         "all"
     cpr <- switch(type,
         "ICC" = lapply(crf.GPCM(betas, z, x$IRT.param), t),
-        "IIC" = infoGPCM(betas, z, x$IRT.param), 
+        "IIC" = infoGPCM(betas, z, x$IRT.param),
         "OCCl" = lapply(crf.GPCM(betas, z, x$IRT.param), function (x) {
                 pp <- apply(x[-nrow(x), , drop = FALSE], 2, cumsum)
                 if (NCOL(pp) == 1) as.matrix(pp) else t(pp)
@@ -61,7 +62,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             if (plot.items) "Item Information Curves" else "Test Information Function"
         }
         mis.ind <- TRUE
-    } else 
+    } else
         mis.ind <- FALSE
     if (missing(ylab)) {
         ylab <- if (type == "ICC" || (type == "OCCl" | type == "OCCu")) "Probability" else "Information"
@@ -78,7 +79,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
         if (ctg == "all") {
             if (plot) {
                 if (length(itms) > 1) {
-                    old.par <- par(ask = TRUE)
+                    old.par <- par(ask = ask)
                     on.exit(par(old.par))
                 }
                 one.fig <- prod(par("mfcol")) == 1
@@ -88,7 +89,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                         main. <- if (one.fig) paste("- Item:", names(cpr)[ii]) else paste("\nItem:", names(cpr)[ii])
                         main <- paste(Main, main.)
                     }
-                    plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+                    plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                          cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
                     p <- cpr[[ii]]
                     pos <- round(seq(10, 90, length = ncol(p)))
@@ -103,7 +104,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                         if (!missing(pch))
                             points(z[pch.ind], p[pch.ind, j], pch = pch[j], col = col[j], cex = cex, ...)
                         if (annot)
-                            text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) j else labels[j], 
+                            text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) j else labels[j],
                                  col = col[j], cex = cex, ...)
                     }
                     if (legend) {
@@ -133,7 +134,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                     main. <- if (one.fig) paste("- Category:", ctg) else paste("\nCategory:", ctg)
                     main <- paste(Main, main.)
                 }
-                plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+                plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                      cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
                 pos <- round(seq(10, 90, length = ncol(p)))
                 col <- rep(col., length.out = length(itms))
@@ -141,19 +142,19 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                 if (!missing(pch)) {
                     pch <- rep(pch, length.out = length(itms))
                     pch.ind <- round(seq(15, 85, length = 4))
-                }                   
+                }
                 for (j in 1:ncol(p)) {
                     lines(z, p[, j], lty = lty[j], col = col[j], ...)
                     if (!missing(pch))
                         lines(z, p[, j], pch = pch[j], col = col[j], cex = cex, ...)
                     if (annot)
-                        text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) colnames(p)[j] else labels[j], 
+                        text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) colnames(p)[j] else labels[j],
                              col = col[j], cex = cex, ...)
                 }
                 if (legend) {
                     ncol. <- if (is.null(ncol)) {
                         if (any(nchar(colnames(p)) > 11)) 1 else length(items) %/% 2
-                    } else 
+                    } else
                         ncol
                     lab <- if (missing(labels)) colnames(p) else labels
                     legend(cx, cy, legend = lab, lty = lty, pch = pch, col = col, bty = bty, ncol = ncol., cex = cex, ...)
@@ -170,7 +171,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             if (mis.ind) {
                 main <- Main
             }
-            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                  cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
             if (plot.items) {
                 col <- rep(col., length.out = length(itms))
@@ -185,12 +186,12 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                     if (!missing(pch))
                         points(z[pch.ind], p[pch.ind, i], pch = pch[i], col = col[i], cex = cex, ...)
                     if (annot)
-                        text(z[pos[i]], p[pos[i], i], adj = c(0, 1.2), if (missing(labels)) i else labels[i], 
+                        text(z[pos[i]], p[pos[i], i], adj = c(0, 1.2), if (missing(labels)) i else labels[i],
                              col = col[i], cex = cex, ...)
                 }
                 if (legend) {
                     ncol. <- if (is.null(ncol)) ncol. <- if (nitems > 8) 2 else 1 else ncol
-                    legend(cx, cy, legend = if (missing(labels)) colnames(cpr)[itms] else labels, lty = lty, pch = pch, 
+                    legend(cx, cy, legend = if (missing(labels)) colnames(cpr)[itms] else labels, lty = lty, pch = pch,
                            col = col, bty = bty, ncol = ncol., cex = cex, ...)
                 }
             } else {

--- a/R/plot.grm.R
+++ b/R/plot.grm.R
@@ -1,10 +1,11 @@
 plot.grm <-
-function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NULL, 
-                      zrange = c(-3.8, 3.8), z = seq(zrange[1], zrange[2], length = 100), annot, 
-                      labels = NULL, legend = FALSE, 
-                      cx = "top", cy = NULL, ncol = 1, bty = "n", col = palette(), lty = 1, pch, 
-                      xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"), 
-                      cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"), 
+function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NULL,
+                      zrange = c(-3.8, 3.8), z = seq(zrange[1], zrange[2], length = 100), annot,
+                      labels = NULL, legend = FALSE,
+                      cx = "top", cy = NULL, ncol = 1, bty = "n", col = palette(), lty = 1, pch,
+                      xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"),
+                      cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"),
+                      ask = TRUE,
                       plot = TRUE, ...) {
     if (!inherits(x, "grm"))
         stop("Use only with 'grm' objects.\n")
@@ -29,7 +30,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             stop(paste("'category' must be a number between 1 and ", max(ncatg), ".\n", sep = ""))
         if (any(ind <- category > ncatg)){
             if (sum(ind) > 1)
-                warning("Items ", paste(items[ind], collapse = ", "), " are excluded since they have only ", 
+                warning("Items ", paste(items[ind], collapse = ", "), " are excluded since they have only ",
                             paste(ncatg[ind], collapse = ", "), " categories, respectively.\n")
             else
                 warning("Item ", items[ind], " is excluded since they have only ", ncatg[ind], " categories.\n")
@@ -38,7 +39,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
         category
     } else
         "all"
-    cpr <- switch(type, "ICC" = iprobs(betas, z), "IIC" = infoprobs(betas, z), 
+    cpr <- switch(type, "ICC" = iprobs(betas, z), "IIC" = infoprobs(betas, z),
                     "OCCl" = cumprobs(betas, z), "OCCu" = cumprobs(betas, z, FALSE))
     plot.items <- type == "ICC" || (type == "IIC" & (is.null(items) || all(items > 0)))
     plot.info <- !plot.items
@@ -51,7 +52,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             if (plot.items) "Item Information Curves" else "Test Information Function"
         }
         mis.ind <- TRUE
-    } else 
+    } else
         mis.ind <- FALSE
     if (missing(ylab)) {
         ylab <- if (type == "ICC" || (type == "OCCl" | type == "OCCu")) "Probability" else "Information"
@@ -68,7 +69,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
         if (ctg == "all") {
             if (plot) {
                 if (length(itms) > 1) {
-                    old.par <- par(ask = TRUE)
+                    old.par <- par(ask = ask)
                     on.exit(par(old.par))
                 }
                 one.fig <- prod(par("mfcol")) == 1
@@ -78,7 +79,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                         main. <- if (one.fig) paste("- Item:", names(cpr)[ii]) else paste("\nItem:", names(cpr)[ii])
                         main <- paste(Main, main.)
                     }
-                    plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+                    plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                          cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
                     p <- cpr[[ii]]
                     pos <- round(seq(10, 90, length = ncol(p)))
@@ -93,7 +94,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                         if (!missing(pch))
                             points(z[pch.ind], p[pch.ind, j], pch = pch[j], col = col[j], cex = cex, ...)
                         if (annot)
-                            text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) j else labels[j], 
+                            text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) j else labels[j],
                                  col = col[j], cex = cex, ...)
                     }
                     if (legend) {
@@ -123,7 +124,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                     main. <- if (one.fig) paste("- Category:", ctg) else paste("\nCategory:", ctg)
                     main <- paste(Main, main.)
                 }
-                plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+                plot(range(z), c(0, 1), type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                      cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
                 pos <- round(seq(10, 90, length = ncol(p)))
                 col <- rep(col., length.out = length(itms))
@@ -131,19 +132,19 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                 if (!missing(pch)) {
                     pch <- rep(pch, length.out = length(itms))
                     pch.ind <- round(seq(15, 85, length = 4))
-                }                   
+                }
                 for (j in 1:ncol(p)) {
                     lines(z, p[, j], lty = lty[j], col = col[j], ...)
                     if (!missing(pch))
                         lines(z, p[, j], pch = pch[j], col = col[j], cex = cex, ...)
                     if (annot)
-                        text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) colnames(p)[j] else labels[j], 
+                        text(z[pos[j]], p[pos[j], j], adj = c(0, 1.2), if (missing(labels)) colnames(p)[j] else labels[j],
                              col = col[j], cex = cex, ...)
                 }
                 if (legend) {
                     ncol. <- if (is.null(ncol)) {
                         if (any(nchar(colnames(p)) > 11)) 1 else length(items) %/% 2
-                    } else 
+                    } else
                         ncol
                     lab <- if (missing(labels)) colnames(p) else labels
                     legend(cx, cy, legend = lab, lty = lty, pch = pch, col = col, bty = bty, ncol = ncol., cex = cex, ...)
@@ -160,7 +161,7 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
             if (mis.ind) {
                 main <- Main
             }
-            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                  cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
             if (plot.items) {
                 col <- rep(col., length.out = length(itms))
@@ -175,12 +176,12 @@ function (x, type = c("ICC", "IIC", "OCCu", "OCCl"), items = NULL, category = NU
                     if (!missing(pch))
                         points(z[pch.ind], p[pch.ind, i], pch = pch[i], col = col[i], cex = cex, ...)
                     if (annot)
-                        text(z[pos[i]], p[pos[i], i], adj = c(0, 1.2), if (missing(labels)) i else labels[i], 
+                        text(z[pos[i]], p[pos[i], i], adj = c(0, 1.2), if (missing(labels)) i else labels[i],
                              col = col[i], cex = cex, ...)
                 }
                 if (legend) {
                     ncol. <- if (is.null(ncol)) ncol. <- if (nitems > 8) 2 else 1 else ncol
-                    legend(cx, cy, legend = if (missing(labels)) colnames(cpr)[itms] else labels, lty = lty, pch = pch, 
+                    legend(cx, cy, legend = if (missing(labels)) colnames(cpr)[itms] else labels, lty = lty, pch = pch,
                            col = col, bty = bty, ncol = ncol., cex = cex, ...)
                 }
             } else {

--- a/R/plot.ltm.R
+++ b/R/plot.ltm.R
@@ -1,9 +1,10 @@
 plot.ltm <-
 function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 3.8),
-                      z = seq(zrange[1], zrange[2], length = 100), annot, 
-                      labels = NULL, legend = FALSE, cx = "topleft", cy = NULL, ncol = 1, bty = "n", 
-                      col = palette(), lty = 1, pch, xlab, ylab, zlab, main, sub = NULL, cex = par("cex"), 
-                      cex.lab = par("cex.lab"), cex.main = par("cex.main"), cex.sub = par("cex.sub"), 
+                      z = seq(zrange[1], zrange[2], length = 100), annot,
+                      labels = NULL, legend = FALSE, cx = "topleft", cy = NULL, ncol = 1, bty = "n",
+                      col = palette(), lty = 1, pch, xlab, ylab, zlab, main, sub = NULL, cex = par("cex"),
+                      cex.lab = par("cex.lab"), cex.main = par("cex.main"), cex.sub = par("cex.sub"),
+                      ask = TRUE,
                       cex.axis = par("cex.axis"), plot = TRUE, ...) {
     if (!inherits(x, "ltm"))
         stop("Use only with 'ltm' objects.\n")
@@ -42,7 +43,7 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
             pch.ind <- round(seq(15, 85, length = 4))
         }
         if (missing(main)) {
-            main <- if (type == "ICC") "Item Characteristic Curves" else { 
+            main <- if (type == "ICC") "Item Characteristic Curves" else {
                 if (plot.items) "Item Information Curves" else "Test Information Function"
             }
         }
@@ -54,7 +55,7 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
         }
         r <- if (type == "ICC") c(0, 1) else { if (plot.info) range(rowSums(pr)) else range(pr[, itms]) }
         if (plot) {
-            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, 
+            plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex,
                  cex.lab = cex.lab, cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
             if (missing(annot)) {
                 annot <- !legend
@@ -67,11 +68,11 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
                         warning("the length of 'labels' is smaller than the length of 'items'.\n")
                     labels
                 }
-                legend(cx, cy, legend = legnd, col = col, lty = lty, bty = bty, ncol = ncol, cex = cex, pch = pch, ...) 
+                legend(cx, cy, legend = legnd, col = col, lty = lty, bty = bty, ncol = ncol, cex = cex, pch = pch, ...)
             }
             if (annot) {
                 pos <- round(seq(10, 90, length = length(itms)))
-                nams <- if (is.null(labels)) { 
+                nams <- if (is.null(labels)) {
                     nms <- if (rownames(betas)[1] == "Item 1") 1:p else rownames(betas)
                     nms[itms]
                 } else {
@@ -86,7 +87,7 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
                     if (!missing(pch))
                         points(z[pch.ind], pr[pch.ind, itms[it]], pch = pch[it], col = col[it], cex = cex, ...)
                     if (annot)
-                        text(z[pos[it]], pr[pos[it], itms[it]], labels = nams[it], adj = c(0, 2), col = col[it], 
+                        text(z[pos[it]], pr[pos[it], itms[it]], labels = nams[it], adj = c(0, 2), col = col[it],
                              cex = cex, ...)
                 }
             }
@@ -145,7 +146,7 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
                 if (missing(main))
                     main <- "Item Characteristic Surfaces"
                 col <- if (missing(col)) rep("white", length.out = length(itms)) else rep(col, length.out = length(itms))
-                old.par <- par(ask = TRUE)
+                old.par <- par(ask = ask)
                 on.exit(par(old.par))
             }
             grid. <- as.matrix(expand.grid(z1, z2))
@@ -156,9 +157,9 @@ function (x, type = c("ICC", "IIC", "loadings"), items = NULL, zrange = c(-3.8, 
                 z[[it]] <- apply(grid., 1, f, betas = betas[item, ], strct = x$ltst)
                 dim(z[[it]]) <- c(length(z1), length(z1))
                 if (plot) {
-                    persp(z1, z2, z[[it]], cex = cex, xlab = list(xlab, cex = cex.lab), 
-                          ylab = list(ylab, cex = cex.lab), zlab = list(zlab, cex = cex.lab), 
-                          main = list(main, cex = cex.main), sub = list(if (is.null(labels)) nams[item] else labels[it], 
+                    persp(z1, z2, z[[it]], cex = cex, xlab = list(xlab, cex = cex.lab),
+                          ylab = list(ylab, cex = cex.lab), zlab = list(zlab, cex = cex.lab),
+                          main = list(main, cex = cex.main), sub = list(if (is.null(labels)) nams[item] else labels[it],
                           cex = cex.sub), col = col[it], ...)
                 }
             }

--- a/R/plot.rasch.R
+++ b/R/plot.rasch.R
@@ -1,9 +1,9 @@
 plot.rasch <-
-function (x, type = c("ICC", "IIC"), items = NULL, zrange = c(-3.8, 3.8), 
-                        z = seq(zrange[1], zrange[2], length = 100), annot, 
-                        labels = NULL, legend = FALSE, cx = "topleft", cy = NULL, ncol = 1, bty = "n", col = palette(), 
-                        lty = 1, pch, xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"), 
-                        cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"), 
+function (x, type = c("ICC", "IIC"), items = NULL, zrange = c(-3.8, 3.8),
+                        z = seq(zrange[1], zrange[2], length = 100), annot,
+                        labels = NULL, legend = FALSE, cx = "topleft", cy = NULL, ncol = 1, bty = "n", col = palette(),
+                        lty = 1, pch, xlab, ylab, main, sub = NULL, cex = par("cex"), cex.lab = par("cex.lab"),
+                        cex.main = par("cex.main"), cex.sub = par("cex.sub"), cex.axis = par("cex.axis"),
                         plot = TRUE, ...) {
     if (!inherits(x, "rasch"))
         stop("Use only with 'rasch' objects.\n")
@@ -37,7 +37,7 @@ function (x, type = c("ICC", "IIC"), items = NULL, zrange = c(-3.8, 3.8),
             pch.ind <- round(seq(15, 85, length = 4))
         }
         if (missing(main)) {
-            main <- if (type == "ICC") "Item Characteristic Curves" else { 
+            main <- if (type == "ICC") "Item Characteristic Curves" else {
                 if (plot.items) "Item Information Curves" else "Test Information Function"
             }
         }
@@ -48,7 +48,7 @@ function (x, type = c("ICC", "IIC"), items = NULL, zrange = c(-3.8, 3.8),
             ylab <- if (type == "ICC") "Probability" else "Information"
         }
         r <- if (type == "ICC") c(0, 1) else { if (plot.info) range(rowSums(pr)) else range(pr[, itms]) }
-        plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, cex.lab = cex.lab, 
+        plot(range(z), r, type = "n", xlab = xlab, ylab = ylab, main = main, sub = sub, cex = cex, cex.lab = cex.lab,
              cex.main = cex.main, cex.axis = cex.axis, cex.sub = cex.sub, ...)
         if (missing(annot)) {
             annot <- !legend
@@ -61,11 +61,11 @@ function (x, type = c("ICC", "IIC"), items = NULL, zrange = c(-3.8, 3.8),
                     warning("the length of 'labels' is smaller than the length of 'items'.\n")
                 labels
             }
-            legend(cx, cy, legend = legnd, col = col, lty = lty, bty = bty, ncol = ncol, cex = cex, pch = pch, ...) 
+            legend(cx, cy, legend = legnd, col = col, lty = lty, bty = bty, ncol = ncol, cex = cex, pch = pch, ...)
         }
         if (annot) {
             pos <- round(seq(10, 90, length = length(itms)))
-            nams <- if (is.null(labels)) { 
+            nams <- if (is.null(labels)) {
                 nms <- if (rownames(betas)[1] == "Item 1") 1:p else rownames(betas)
                 nms[itms]
             } else {


### PR DESCRIPTION
Hello,

This is a small patch to allow plots to be overwritten with ask = FALSE, so that the prompts to press enter can be avoided. For example, after a GRM model one can do plot(grm, ask = FALSE) and all plots will be displayed immediately.

My RStudio also automatically made a few minor formatting edits to a few lines so apologies that those are complicating the PR a bit.

Thanks,
Chris